### PR TITLE
Use Cloudinary full project release, not the sandbox.

### DIFF
--- a/cloudinary.make
+++ b/cloudinary.make
@@ -13,12 +13,7 @@ projects[] = redis
 projects[] = mongodb
 projects[] = admin_menu
 projects[] = module_filter
-
-; Cloudinary module from drupal sandbox
-projects[cloudinary][type] = "module"
-projects[cloudinary][download][type] = "git"
-projects[cloudinary][download][url] = "http://git.drupal.org/sandbox/everright/2444793.git"
-projects[cloudinary][download][branch] = "7.x-1.x"
+projects[] = cloudinary
 
 ; Cloudinary PHP SDK
 libraries[cloudinary][download][type]= "git"


### PR DESCRIPTION
Since the module has been already released as full project on drupal.org, we can switch to use it.
